### PR TITLE
Example of fetching data in React Server Component with @apollo/exper…

### DIFF
--- a/app/graphql/apollo-server-component/ApolloClient.ts
+++ b/app/graphql/apollo-server-component/ApolloClient.ts
@@ -1,0 +1,19 @@
+import { HttpLink } from "@apollo/client";
+import {
+  registerApolloClient,
+  ApolloClient,
+  InMemoryCache,
+} from "@apollo/experimental-nextjs-app-support";
+
+export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
+  return new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new HttpLink({
+      // this needs to be an absolute url, as relative urls cannot be used in SSR
+      uri: "https://countries.trevorblades.com/",
+      // you can disable result caching here if you want to
+      // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
+      // fetchOptions: { cache: "no-store" },
+    }),
+  });
+});

--- a/app/graphql/apollo-server-component/ApolloWrapper.tsx
+++ b/app/graphql/apollo-server-component/ApolloWrapper.tsx
@@ -1,0 +1,40 @@
+'use client';
+// ^ this file needs the "use client" pragma
+
+import { HttpLink } from "@apollo/client";
+import {
+  ApolloNextAppProvider,
+  ApolloClient,
+  InMemoryCache,
+} from "@apollo/experimental-nextjs-app-support";
+
+// have a function to create a client for you
+function makeClient() {
+  const httpLink = new HttpLink({
+    // this needs to be an absolute url, as relative urls cannot be used in SSR
+    uri: "https://countries.trevorblades.com/",
+    // you can disable result caching here if you want to
+    // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
+    fetchOptions: { cache: "no-store" },
+    // you can override the default `fetchOptions` on a per query basis
+    // via the `context` property on the options passed as a second argument
+    // to an Apollo Client data fetching hook, e.g.:
+    // const { data } = useSuspenseQuery(MY_QUERY, { context: { fetchOptions: { cache: "force-cache" }}});
+  });
+
+  // use the `ApolloClient` from "@apollo/experimental-nextjs-app-support"
+  return new ApolloClient({
+    // use the `InMemoryCache` from "@apollo/experimental-nextjs-app-support"
+    cache: new InMemoryCache(),
+    link: httpLink,
+  });
+}
+
+// you need to create a component to wrap your app in
+export function ApolloWrapper({ children }: React.PropsWithChildren) {
+  return (
+    <ApolloNextAppProvider makeClient={makeClient}>
+      {children}
+    </ApolloNextAppProvider>
+  );
+}

--- a/app/graphql/apollo-server-component/ServerComponentExample.tsx
+++ b/app/graphql/apollo-server-component/ServerComponentExample.tsx
@@ -1,0 +1,22 @@
+import { gql } from "@apollo/client";
+import { getClient } from "./ApolloClient";
+
+const GET_ALL_TODOS = gql`
+  query {
+    countries {
+      name
+    }
+  }
+`;
+//This is true Server Component
+export default async function ServerComponentExample() {
+
+    const { data } = await getClient().query({ query: GET_ALL_TODOS });
+    return (
+        <ul>
+          { data.countries.map((country: {name: string}) => (
+            <li key={country.name}>{country.name}</li>
+          ))}
+        </ul>
+      )
+}

--- a/app/graphql/apollo-server-component/page.tsx
+++ b/app/graphql/apollo-server-component/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import ServerComponentExample from "./ServerComponentExample";
+import { ApolloWrapper } from "./ApolloWrapper";
+//Server component page example
+export default function ApolloServerComponent() {
+
+    return (
+        <>
+        <ApolloWrapper>
+            <h1>Server component fetching</h1>
+            <Suspense fallback={<p>Loading counties...</p>}>
+                <ServerComponentExample />
+            </Suspense>
+        </ApolloWrapper>
+    </>)
+}


### PR DESCRIPTION
Example of fetching data in `React Server Component` with `@apollo/experimental-nextjs-app-support`

PS: I've used the same `ApolloWraper.tsx` as you did before, just copied it to the `apollo-server-component` folder.